### PR TITLE
Adapting the training for use in NLTK

### DIFF
--- a/Inside-Outside-Algorithm/train.py
+++ b/Inside-Outside-Algorithm/train.py
@@ -9,11 +9,15 @@ def train(cfg_file,train_file,iter_num=20):
     (name,ext) = os.path.splitext(train_file)
     state = pcfg.EM(iter_num=iter_num)
     with open(name+'.pcfg','w') as f:
-        for (A,w) in cfg.unary_rules:
-            f.writelines(A+'->'+w+' '+str(state.get((A,w)))+'\n')
-
         for (A,B,C) in cfg.binary_rules:
-            f.writelines(A+'->'+B+' '+C+' '+str(state.get((A,B,C)))+'\n')
+            f.writelines(A+' -> '+B+' '+C+' '+str(state.get((A,B,C)))+'\n')
+
+        for (A,w) in cfg.unary_rules:
+            f.writelines(A+' -> '+w+' '+str(state.get((A,w)))+'\n')
+
+        
+
+
     with open(name+'.gen','w') as f:
           for i in range(2000):
               f.writelines(pcfg.gen_sentence('S')+'\n')


### PR DESCRIPTION
Hi,

Thank you for sharing this code, it really helped me with my research! I have added a simple change. I wanted to use the generated PCFGs with NLTK later, but it didn't work because NLTK couldn't find a start symbol (S) - it assumed it's in the first line.
 What worked for me, is that I changed the order of rules generation - so the binary rules go first, unary rules later. I also added spaces around the arrows because it also caused errors.

I hope that helps someone :)
