### PR TITLE
Training & Grammar File now added from command line

### DIFF
--- a/Inside-Outside-Algorithm/train.py
+++ b/Inside-Outside-Algorithm/train.py
@@ -3,6 +3,12 @@ __author__ = 'zhouyang'
 from CFG import CFG
 from PCFG_EM import PCFG_EM
 import os
+import sys
+
+
+
+
+
 def train(cfg_file,train_file,iter_num=20):
     cfg = CFG(cfg_file=cfg_file)
     pcfg = PCFG_EM(train_file=train_file,CFG=cfg)
@@ -16,16 +22,18 @@ def train(cfg_file,train_file,iter_num=20):
             f.writelines(A+' -> '+w+' '+str(state.get((A,w)))+'\n')
 
         
-
-
     with open(name+'.gen','w') as f:
           for i in range(2000):
               f.writelines(pcfg.gen_sentence('S')+'\n')
 
+
+gram_file = sys.argv[1]
+train_file = sys.argv[2]
+
 if __name__ == '__main__':
     #train('test/emile.cfg','test/emile.train')
     #train('test/test2.cfg','test/test2.train')
-    train('test/test3.cfg','test/test3.train')
+    train(gram_file,train_file)
     #train('test/test4.cfg','test/test4.train')
     #train('test/test5.cfg','test/test5.train')
     #train('test/test3.cfg','test/test3.train')


### PR DESCRIPTION
This simple change can help automate some tasks - now to use a grammar.cfg and training file file.train user should type as following

`python train.py grammar.cfg file.train`

instead of changing the train.py itself